### PR TITLE
他人のプロフィールページが閲覧できる Feature/other-profiles

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
 
   private
 
-  def set_post
+  def set_user
     @user = User.find(params[:id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,11 @@
+class UsersController < ApplicationController
+  before_action :set_user, only: %i[show]
+
+  def show; end
+
+  private
+
+  def set_post
+    @user = User.find(params[:id])
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :active_relationships, class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy, inverse_of: 'follower'
   has_many :followings, through: :active_relationships, source: :followed
-  validates :name, presence: true, format: { with: /\A\w+\z/ }, length: { maximum: 20 }
+  validates :name, presence: true, format: { with: /\A[\w_.-]+\z/, message: 'の入力形式が違います' }, length: { maximum: 20 }
 
   def follow!(user_id)
     active_relationships.create!(followed_id: user_id)

--- a/app/views/posts/_posts.html.haml
+++ b/app/views/posts/_posts.html.haml
@@ -2,7 +2,8 @@
   - posts.each do |post|
     %li.list-group-item.p-2
       .fs-6
-        = post.user.name
+        = link_to user_path(post.user), class: 'text-decoration-none text-body' do
+          post.user.name
       .d-flex.justify-content-between
         = link_to post_path(post), class: 'text-decoration-none text-body' do
           .fs-5

--- a/app/views/posts/_posts.html.haml
+++ b/app/views/posts/_posts.html.haml
@@ -3,7 +3,7 @@
     %li.list-group-item.p-2
       .fs-6
         = link_to user_path(post.user), class: 'text-decoration-none text-body' do
-          post.user.name
+          = post.user.name
       .d-flex.justify-content-between
         = link_to post_path(post), class: 'text-decoration-none text-body' do
           .fs-5

--- a/app/views/users/profiles/edit.html.haml
+++ b/app/views/users/profiles/edit.html.haml
@@ -2,5 +2,5 @@
   = simple_form_for @user, url: profile_path do |f|
     = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
     = f.input :about_me
-    = f.url_field :blog_url
+    = f.url_field :blog_url, placeholder: 'ブログのURLを入力'
     = f.button :submit, class: 'btn btn-primary'

--- a/app/views/users/profiles/show.html.haml
+++ b/app/views/users/profiles/show.html.haml
@@ -1,1 +1,1 @@
-= render 'users/shared/profile', user: @user, with_edit_btn: true
+= render 'users/shared/profile', user: @user, with_edit_btn: current_user == @user

--- a/app/views/users/profiles/show.html.haml
+++ b/app/views/users/profiles/show.html.haml
@@ -1,9 +1,1 @@
-.p-4.d-flex.flex-column.justify-content-center.mt-6
-  .post-container.p-3
-    .mb-3
-      = @user.name
-    .mb-3
-      = @user.about_me
-    .mb-3 
-      = @user.blog_url
-    = link_to '編集', edit_profile_path, class: 'btn btn-success'
+= render 'users/shared/profile', user: @user, with_edit_btn: true

--- a/app/views/users/shared/_profile.html.haml
+++ b/app/views/users/shared/_profile.html.haml
@@ -1,0 +1,11 @@
+- with_edit_btn ||= false
+.p-4.d-flex.flex-column.justify-content-center.mt-6
+  .post-container.p-3
+    .mb-3
+      = @user.name
+    .mb-3
+      = @user.about_me
+    .mb-3 
+      = @user.blog_url
+    - if with_edit_btn  
+      = link_to '編集', edit_profile_path, class: 'btn btn-success'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,0 +1,2 @@
+%h1 Users#show
+%p Find me in app/views/users/show.html.haml

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,2 +1,1 @@
-%h1 Users#show
-%p Find me in app/views/users/show.html.haml
+= render 'users/shared/profile', user: @user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
   resources :posts, only: %i[index show] do
     resource :likes, only: %i[create destroy], module: :posts
   end
+  resources :users, only: %i[show]
 end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'プロフィール機能', type: :system do
     sign_in user
   end
 
-  context 'ログインしている時' do
+  context '自分のプロフィールの時' do
     it '自分のプロフィールを確認できること' do
       visit root_path
       within('.nav') do
@@ -16,6 +16,37 @@ RSpec.describe 'プロフィール機能', type: :system do
       expect(page).to have_content 'jojo'
       expect(page).to have_content '私の名前は空条承太郎です'
       expect(page).to have_content 'google.com'
+    end
+
+    it '自分のプロフィールを編集できること' do
+      visit profile_path
+      click_on '編集'
+      fill_in '自己紹介',	with: '自己紹介をします'
+      fill_in 'user_blog_url', with: 'taji.blog'
+      click_on '更新する'
+      expect(page).to have_content '自己紹介をします'
+      expect(page).to have_content 'taji.blog'
+      expect(page).not_to have_content '私の名前は空条承太郎です'
+      expect(page).not_to have_content 'google.com'
+    end
+  end
+
+  context '他人のプロフィールの時' do
+    let(:other) { create(:user, name: 'dio', about_me: '私の名前はdioです', blog_url: 'taji.blog') }
+
+    before do
+      create(:post, user: other, content: 'wryyyyyyy')
+    end
+
+    it '他人のプロフィールを確認できること' do
+      visit root_path
+      within '.list-group-item' do
+        expect(page).to have_content 'wryyyyyyy'
+        click_on 'dio'
+      end
+      expect(page).to have_content 'dio'
+      expect(page).to have_content '私の名前はdioです'
+      expect(page).to have_content 'taji.blog'
     end
   end
 end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'プロフィール機能', type: :system do
   end
 
   context '自分のプロフィールの時' do
-    it '自分のプロフィールを確認できること' do
+    it '確認できること' do
       visit root_path
       within('.nav') do
         click_on 'プロフィール'
@@ -18,7 +18,7 @@ RSpec.describe 'プロフィール機能', type: :system do
       expect(page).to have_content 'google.com'
     end
 
-    it '自分のプロフィールを編集できること' do
+    it '編集できること' do
       visit profile_path
       click_on '編集'
       fill_in '自己紹介',	with: '自己紹介をします'
@@ -38,7 +38,7 @@ RSpec.describe 'プロフィール機能', type: :system do
       create(:post, user: other, content: 'wryyyyyyy')
     end
 
-    it '他人のプロフィールを確認できること' do
+    it '確認できること' do
       visit root_path
       within '.list-group-item' do
         expect(page).to have_content 'wryyyyyyy'
@@ -47,6 +47,11 @@ RSpec.describe 'プロフィール機能', type: :system do
       expect(page).to have_content 'dio'
       expect(page).to have_content '私の名前はdioです'
       expect(page).to have_content 'taji.blog'
+    end
+
+    it '編集できないこと' do
+      visit user_path(other)
+      expect(page).not_to have_content '編集'
     end
   end
 end


### PR DESCRIPTION
#16 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ユーザーのプロフィールページにリンクする表示を追加。
  - プロフィール情報を表示する新しい部分テンプレートを導入。

- **改善**
  - ユーザープロフィールの編集フォームにプレースホルダーを追加。
  - ユーザープロフィール表示ページを部分テンプレートにリファクタリング。

- **バグ修正**
  - `name`属性のバリデーションに新しい正規表現パターンとカスタムエラーメッセージを追加。

- **テスト**
  - プロフィール機能のテストケースをシナリオごとに更新し、他人のプロフィールを閲覧するケースを追加。

- **ルーティング**
  - ユーザーの`show`アクションへの新しいルートを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->